### PR TITLE
Confirm buffer is file before adding to list

### DIFF
--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -79,9 +79,13 @@ endfunction
 
 function! s:RunAnalysis(files)
   echo 'Running codeclimate analyze...'
-  let l:analyze_output = system(g:vimcodeclimate_analyze_cmd.' '.a:files)
+  let l:analyze_cmd = g:vimcodeclimate_analyze_cmd.' '.a:files
+  let l:analyze_output = system(l:analyze_cmd)
   if v:shell_error
-    echohl ErrorMsg | echo 'codeclimate failed: try `codeclimate validate-config` or `codeclimate analyze` in your shell.' |  echohl None
+    echohl ErrorMsg
+    echo 'codeclimate failed: try `codeclimate validate-config` or `codeclimate analyze` in your shell.'
+    echo 'failed command: '.l:analyze_cmd
+    echohl None
     return
   endif
   let l:issues = []

--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -47,7 +47,7 @@ function! s:EligibleBuffers()
   let l:bufs = []
   let l:idx = bufnr('^')
   while l:idx <= bufnr('$')
-    if '' ==# getbufvar(l:idx, '&buftype')
+    if '' ==# getbufvar(l:idx, '&buftype') && filereadable(expand('#'.l:idx.':p'))
       call add(l:bufs, l:idx)
     endif
     let l:idx = l:idx + 1


### PR DESCRIPTION
I saw some commands fail locally because some buffers would expand ":p"
to a string like "/path/to/repo/dir (Bound to SomeFile.hs)", which
obviously isn't actually a file & creates an invalid command line
invocation. This seems to happen when I open vim by just typing `vim` without any
file arguments, and then open files from within the editor.

The fix here is to shell each path out to the `file` command & check
that command ran without error to have some level of confidence the path
we got from the buffer is indeed a file.
