### PR TITLE
Include issues that affect a set of lines.

### DIFF
--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -94,11 +94,13 @@ function! s:RunAnalysis(files)
   endif
   let l:issues = []
   let l:currentFile = ''
+  let l:lineNumber = ''
   for l:line in split(l:analyze_output, "\n")
     if 0 == stridx(l:line, '== ')
       let l:currentFile = substitute(l:line, '^== \(.\+\) (.\+==$', '\1', 'i')
-    elseif matchstr(l:line, '^\d\+\:')
-      call add(l:issues, l:currentFile.':'.l:line)
+    elseif matchstr(l:line, '^\d\+-\=\d\+\:')
+      let l:lineNumber = substitute(l:line, '^\(\d\+\)\(\-\=\d\+\)\(\:.*\)', '\1\3', 'g')
+      call add(l:issues, l:currentFile.':'.l:lineNumber)
     endif
   endfor
   if 0 == len(l:issues)


### PR DESCRIPTION
For example the Cyclomatic complexity will produce lines like:
70-122: Cyclomatic complexity for method is too high. [9/6][rubocop]
70-122: Method has too many lines. [41/30] [rubocop]

These issues were not being included in the results of the analysis.
