### PR TITLE
Issue #3: Issue with line numbers

### DIFF
--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -98,8 +98,8 @@ function! s:RunAnalysis(files)
   for l:line in split(l:analyze_output, "\n")
     if 0 == stridx(l:line, '== ')
       let l:currentFile = substitute(l:line, '^== \(.\+\) (.\+==$', '\1', 'i')
-    elseif matchstr(l:line, '^\d\+-\=\d\+\:')
-      let l:lineNumber = substitute(l:line, '^\(\d\+\)\(\-\=\d\+\)\(\:.*\)', '\1\3', 'g')
+    elseif matchstr(l:line, '^\d\+[-=]\d\+\:')
+      let l:lineNumber = substitute(l:line, '^\(\d\+\)\([-=]\d\+\)\(\:.*\)', '\1\3', 'g')
       call add(l:issues, l:currentFile.':'.l:lineNumber)
     endif
   endfor

--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -98,7 +98,7 @@ function! s:RunAnalysis(files)
   for l:line in split(l:analyze_output, "\n")
     if 0 == stridx(l:line, '== ')
       let l:currentFile = substitute(l:line, '^== \(.\+\) (.\+==$', '\1', 'i')
-    elseif matchstr(l:line, '^\d\+[-=]\d\+\:')
+    elseif matchstr(l:line, '^\d\+-\=\d\+\:')
       let l:lineNumber = substitute(l:line, '^\(\d\+\)\([-=]\d\+\)\(\:.*\)', '\1\3', 'g')
       call add(l:issues, l:currentFile.':'.l:lineNumber)
     endif


### PR DESCRIPTION
When you run the vim-codeclimate commands the line numbers don't
correspond to the codeclimate CLI output (turns out they were being
trimmed to first char).

The issue is with the regex and in particular the hyphen in the regex
which I think is being interpreted as a range. Putting it in a character
set solves the problem.

I haven't been throught the code cliamte code but I tried running the
cli in a number of scenarios and I only ever got output for line numbers
that fit on of the following forms:
- 000(n)
- 000(n)-000(n)

I didn't ever get the equals sign to appear but I've included that in
the character set.

If the CLI output can ever be any other output form then this regex will
need revisiting.

Any questions let me know.

Cheers,

Amo
@sysadmiral
