### PR TITLE
Add Tests, Refactor Issue Parsing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,4 +7,5 @@ engines:
 ratings:
   paths:
     - "**/*.vim"
-exclude_paths: []
+exclude_paths:
+  - t/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+.vim-flavor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+script: make citest

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'vim-flavor', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    blankslate (3.1.3)
+    parslet (1.7.1)
+      blankslate (>= 2.0, <= 4.0)
+    thor (0.19.1)
+    vim-flavor (1.1.5)
+      parslet (~> 1.0)
+      thor (~> 0.14)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  vim-flavor (~> 1.1)
+
+BUNDLED WITH
+   1.11.2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test citest vim_info
+
+test:
+	bundle exec vim-flavor test
+
+vim_info:
+	vim --version
+
+citest: vim_info test

--- a/VimFlavor.lock
+++ b/VimFlavor.lock
@@ -1,0 +1,1 @@
+kana/vim-vspec (1.6.1)

--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -106,9 +106,9 @@ function! s:ParseIssues(text)
   let l:lineNumber = ''
   for l:line in split(a:text, "\n")
     if 0 == stridx(l:line, '== ')
-      let l:currentFile = substitute(l:line, '^== \(.\+\) (.\+==$', '\1', 'i')
-    elseif matchstr(l:line, '^\d\+-\=\d\+\:')
-      let l:lineNumber = substitute(l:line, '^\(\d\+\)\([-=]\d\+\)\(\:.*\)', '\1\3', 'g')
+      let l:currentFile = substitute(l:line, '\v^\=\= (.+) \(.+\=\=$', '\1', 'i')
+    elseif matchstr(l:line, '\v^\d+(-\d+)?:')
+      let l:lineNumber = substitute(l:line, '\v^(\d+)(-\d+)(:.*)', '\1\3', 'g')
       call add(l:issues, l:currentFile.':'.l:lineNumber)
     endif
   endfor

--- a/plugin/codeclimate.vim
+++ b/plugin/codeclimate.vim
@@ -92,10 +92,19 @@ function! s:RunAnalysis(files)
     echohl None
     return
   endif
+  let l:issues = s:ParseIssues(l:analyze_output)
+  if 0 == len(l:issues)
+    echo 'Code Climate found no issues! Well done.'
+  else
+    call s:ShowIssues(l:issues)
+  endif
+endfunction
+
+function! s:ParseIssues(text)
   let l:issues = []
   let l:currentFile = ''
   let l:lineNumber = ''
-  for l:line in split(l:analyze_output, "\n")
+  for l:line in split(a:text, "\n")
     if 0 == stridx(l:line, '== ')
       let l:currentFile = substitute(l:line, '^== \(.\+\) (.\+==$', '\1', 'i')
     elseif matchstr(l:line, '^\d\+-\=\d\+\:')
@@ -103,11 +112,7 @@ function! s:RunAnalysis(files)
       call add(l:issues, l:currentFile.':'.l:lineNumber)
     endif
   endfor
-  if 0 == len(l:issues)
-    echo 'Code Climate found no issues! Well done.'
-  else
-    call s:ShowIssues(l:issues)
-  endif
+  return l:issues
 endfunction
 
 function! s:ShowIssues(issues)
@@ -146,6 +151,11 @@ function! s:QuickHelp()
 
   nnoremap <silent> <buffer> ? :q!<CR>:copen<CR>:call <SID>BindQuickShortcuts()<CR>
 endfunction
+
+function! codeclimate#sid()
+  return maparg('<SID>', 'n')
+endfunction
+nnoremap <SID>  <SID>
 
 command! CodeClimateAnalyzeProject :call <SID>AnalyzeProject()
 command! CodeClimateAnalyzeOpenFiles :call <SID>AnalyzeOpenFiles()

--- a/t/codeclimate_spec.vim
+++ b/t/codeclimate_spec.vim
@@ -1,0 +1,18 @@
+source plugin/codeclimate.vim
+call vspec#hint({'sid': 'codeclimate#sid()'})
+
+describe "codeclimate#ParseIssues"
+  it "handles single and multiline issues"
+    let l:ccOutput = "== file.sh (13 issues) ==\n59: issue desc a [engine]\n10-20: issue desc b [engine]\n"
+    let l:parsedIssues = Call("s:ParseIssues", l:ccOutput)
+    let l:expectedIssues = ["file.sh:59: issue desc a [engine]", "file.sh:10: issue desc b [engine]"]
+    Expect l:parsedIssues == l:expectedIssues
+  end
+
+  it "handles multiple files"
+    let l:ccOutput = "== file.sh (13 issues) ==\n59: issue desc a [engine]\n\n== other.rb (1 issue) ==\n10-20: issue desc b [wtf]\n"
+    let l:parsedIssues = Call("s:ParseIssues", l:ccOutput)
+    let l:expectedIssues = ["file.sh:59: issue desc a [engine]", "other.rb:10: issue desc b [wtf]"]
+    Expect l:parsedIssues == l:expectedIssues
+  end
+end


### PR DESCRIPTION
The regex code for parsing CC CLI output into a format usable for QuickFix has been responsible for both bugs that have come up so far on this plugin. It seems like it's a good time to try and test things to prevent future regressions.

As part of writing the test suite, I refactored the existing code a bit to clean it up. Since there are tests now, it was much easier to do that & be confident I wasn't breaking it.

@pbrisbin @gordondiggs @dblandin @sysadmiral Any thoughts on this would be appreciated.

One particular thing I'm not 100% clear on is if there are any major ramifications of moving the source from `plugin` to `autoload` that I should be thinking about. I only made that move because `vspec` wasn't loading from `plugin`, and I couldn't figure out how to make it do that.
